### PR TITLE
도서 예약 상태 유지

### DIFF
--- a/store/useBookStore.jsx
+++ b/store/useBookStore.jsx
@@ -1,0 +1,32 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+const useBookStore = create(
+  persist(
+    (set, get) => ({
+      myReservedBooks: [], // 내가 예약한 책 ID 배열
+
+      addReservation: (bookId) => {
+        //배열에 예약하려는 책 ID가 있는지 확인
+        if (!get().myReservedBooks.includes(bookId)) {
+          set((state) => ({
+            myReservedBooks: [...state.myReservedBooks, bookId],
+          }));
+        }
+      },
+
+      removeReservation: (bookId) => {
+        set((state) => ({
+          myReservedBooks: state.myReservedBooks.filter((id) => id !== bookId),
+        }));
+      },
+
+      isReserved: (bookId) => get().myReservedBooks.includes(bookId),
+    }),
+    {
+      name: "my_reserved_books", // localStorage 저장 키
+    }
+  )
+);
+
+export default useBookStore;


### PR DESCRIPTION
## ✴ PR 요약
- 도서 예약 및 취소 상태 유지를 위한 스토어훅 생성
- 도서 예약 인원 실시간 반영
## 📝 작업 상세
- 페이지가 새로 고침 되어도 도서 예약 상태를 유지하기 위해 useBookStore 스토어훅 생성
- useBookStore를 사용하여 예약에 성공한 도서는 로컬 스토리지에 저장하여 예약 상태 유지
- 기존에 예약 인원이 바로 업데이트 되지 않는 문제를 예약 또는 취소가 성공하면 직접 book 상태를 업데이트하여 바로 반영되도록 하였습니다.