### PR TITLE
공통 레이아웃 스타일 수정 및 사용자의 학과 정보 속성 이름 변경

### DIFF
--- a/src/components/Layout/Layout.jsx
+++ b/src/components/Layout/Layout.jsx
@@ -14,7 +14,7 @@ const Layout = ({ hero, content }) => {
       {isLogined ? (
         <>
           {hero && hero}
-          <div className={style.main}>{content}</div>
+          <div className={style.contents}>{content}</div>
         </>
       ) : (
         <GuestBlock />

--- a/src/components/Layout/Layout.module.css
+++ b/src/components/Layout/Layout.module.css
@@ -4,8 +4,9 @@
   height: 100%;
 }
 
-.main {
-  flex: 1;
+.contents {
   display: flex;
+  flex: 1;
   justify-content: center;
+  padding: 2rem;
 }

--- a/src/pages/MyPage/MyPage.jsx
+++ b/src/pages/MyPage/MyPage.jsx
@@ -9,7 +9,6 @@ import { requestWithAuth } from "../../utils/requestWithAuth";
 const MyPage = () => {
   const [image, setImage] = useState("사진");
   const [file, setFile] = useState("");
-  const [selectedDepartment, setSelectedDepartment] = useState("");
   const [passwordError, setPasswordError] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");
   const [phoneNumberError, setPhoneNumberError] = useState("");
@@ -22,7 +21,7 @@ const MyPage = () => {
     newPassword: "",
     confirmNewPassword: "",
     name: "",
-    department: "",
+    userDepartment: "",
     departments: [],
     studentId: "",
     grade: "",
@@ -36,7 +35,7 @@ const MyPage = () => {
   const {
     prePassword,
     newPassword,
-    department,
+    userDepartment,
     grade,
     phoneNumber,
     departmentPublic,
@@ -48,13 +47,13 @@ const MyPage = () => {
   const newUserInfo = {
     prePassword,
     newPassword,
+    userDepartment,
     grade,
     phoneNumber,
     departmentPublic,
     studentIdPublic,
     gradePublic,
     phonePublic,
-    department: selectedDepartment,
   };
 
   const [modifyMode, setModifyMode] = useState(false);
@@ -90,6 +89,7 @@ const MyPage = () => {
       if (response === null) {
         throw new Error();
       }
+      await requestUserInfo();
       swal({
         title: "정보가 수정되었습니다.",
         icon: "success",
@@ -137,9 +137,6 @@ const MyPage = () => {
     });
 
     switch (name) {
-      case "departments":
-        setSelectedDepartment(value);
-        break;
       case "newPassword":
         passwordCheck(value);
         break;
@@ -241,7 +238,7 @@ const MyPage = () => {
                   <UserInput
                     type="password"
                     name="prePassword"
-                    placeholder="기존 비밀번호"
+                    placeholder={modifyMode ? "기존 비밀번호" : ""}
                     onChange={onChange}
                     disabled={!modifyMode}
                   />
@@ -290,12 +287,12 @@ const MyPage = () => {
               <div className={style.field}>
                 <label>학과</label>
                 <select
-                  name="department"
+                  name="userDepartment"
                   onChange={onChange}
-                  value={selectedDepartment}
+                  value={userInfo.userDepartment}
                   disabled={!modifyMode}
                 >
-                  <option value={userInfo?.department}></option>
+                  <option value={userInfo?.userDepartment}></option>
                   {userInfo?.departments?.map((depart, index) => (
                     <option key={index} value={depart}>
                       {depart}

--- a/src/pages/MyPage/MyPage.module.css
+++ b/src/pages/MyPage/MyPage.module.css
@@ -4,8 +4,6 @@
   justify-content: center;
   gap: 10px;
   width: 600px;
-  margin-top: 2rem;
-  margin-bottom: 2rem;
 }
 
 .container h3 {

--- a/src/pages/SearchBook/SearchBook.module.css
+++ b/src/pages/SearchBook/SearchBook.module.css
@@ -1,6 +1,5 @@
 .container {
   width: 1000px;
-  padding: 2rem 0;
 }
 
 .outline {


### PR DESCRIPTION
## ✴ PR 요약
- 공통 레이아웃 컴포넌트에 패딩 추가
- 마이페이지의 사용자 학과 정보를 나타내는 속성 이름 변경
- 전체 도서 조회 및 마이페이지 마진 및 패딩 제거
## 📝 작업 상세
- 사용자 학과 정보를 나타내는 속성을 department에서 userDepartment로 변경
- 마이페이지에서 정보 수정 시에만 비밀번호 필드에 "기존 비밀번호" placeholder가 나타나도록 조건부 렌더링 추가
- 공통 레이아웃 컴포넌트에 패딩을 추가하면서, 중복된 마진 및 패딩을 개별 컴포넌트에서 제거