### PR TITLE
로그아웃 커스텀 훅 구현 및 에러 처리

### DIFF
--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -10,19 +10,17 @@ const Header = () => {
   const isLogined = useUserStore((state) => state.isLogined);
   const setIsLogined = useUserStore((state) => state.setIsLogined);
   const role = useUserStore((state) => state.role);
-  const setRole = useUserStore((state) => state.setRole);
   const name = useUserStore((state) => state.name);
   const department = useUserStore((state) => state.department);
-  const setUserInfo = useUserStore((state) => state.setUserInfo);
 
   const [toggle, setToggle] = useState(false);
 
   const onLogout = () => {
-    setIsLogined(false);
-    setRole(null);
-    setUserInfo(null, null);
-    localStorage.removeItem("accessToken");
-    swal("로그아웃", "로그아웃 되었습니다.", "success");
+    swal("로그아웃", "로그아웃 되었습니다.", "success").then(() => {
+      setIsLogined(false);
+      localStorage.removeItem("accessToken");
+      setIsMenuVisible(false); // 로그아웃 하면 메뉴바 안열리도록
+    });
   };
 
   const adminMenuItems = [
@@ -55,10 +53,15 @@ const Header = () => {
   return (
     <header>
       <div className={style.HeaderContents}>
-        <div className={style.bars} onMouseEnter={() => setIsMenuVisible(true)}>
+        <div
+          className={style.bars}
+          onMouseEnter={() => {
+            if (isLogined) setIsMenuVisible(true);
+          }}
+        >
           <FaBars />
         </div>
-        {isMenuVisible && (
+        {isMenuVisible && isLogined && (
           <div
             className={style.sideMenu}
             onMouseLeave={() => setIsMenuVisible(false)}

--- a/src/components/UserInput/UserInput.jsx
+++ b/src/components/UserInput/UserInput.jsx
@@ -1,6 +1,7 @@
 import style from "./UserInput.module.css";
 
 const UserInput = ({
+  inputKey,
   type,
   placeholder,
   value,
@@ -12,6 +13,7 @@ const UserInput = ({
   return (
     <input
       className={style.userInput}
+      key={inputKey}
       type={type}
       placeholder={placeholder}
       value={value}

--- a/src/hooks/useLogout.jsx
+++ b/src/hooks/useLogout.jsx
@@ -1,0 +1,22 @@
+import { useNavigate } from "react-router-dom";
+import swal from "sweetalert";
+import useUserStore from "../../store/useUserStore";
+
+export const useLogout = () => {
+  const navigate = useNavigate();
+  const setIsLogined = useUserStore((state) => state.setIsLogined);
+
+  return () => {
+    setIsLogined(false);
+    localStorage.removeItem("accessToken");
+
+    swal({
+      title: "세션이 만료되었습니다.",
+      text: "다시 로그인해 주세요.",
+      icon: "error",
+      button: "확인",
+    }).then(() => {
+      navigate("/login");
+    });
+  };
+};

--- a/src/pages/Login/Login_Page.jsx
+++ b/src/pages/Login/Login_Page.jsx
@@ -20,7 +20,8 @@ const Login = () => {
   const navigate = useNavigate();
   const setIsLogined = useUserStore((state) => state.setIsLogined);
   const setRole = useUserStore((state) => state.setRole);
-  const setUserInfo = useUserStore((state) => state.setUserInfo);
+  const setUserName = useUserStore((state) => state.setUserName);
+  const setUserDepartment = useUserStore((state) => state.setUserDepartment);
 
   const onChange = (e) => {
     const { name, value } = e.target;
@@ -48,13 +49,13 @@ const Login = () => {
             withCredentials: true,
           }
         );
-
         if (response.data.success) {
           console.log(response.data.data.message);
           localStorage.setItem(ACCESS_TOKEN, response.data.data.accessToken);
           setIsLogined(true);
           setRole(response.data.data.role);
-          setUserInfo(response.data.data.name, response.data.data.department);
+          setUserName(response.data.data.name);
+          setUserDepartment(response.data.data.department);
           navigate("/"); // 로그인 후 이동할 페이지 설정
         }
       } catch (error) {

--- a/src/pages/SearchBook/SearchBook.jsx
+++ b/src/pages/SearchBook/SearchBook.jsx
@@ -6,6 +6,7 @@ import style from "./SearchBook.module.css";
 import useUserStore from "../../../store/useUserStore";
 import Book from "../../components/Book/Book";
 import { useNavigate } from "react-router-dom";
+import { useLogout } from "../../hooks/useLogout";
 
 const SearchBook = () => {
   const [books, setBooks] = useState([]);
@@ -13,11 +14,12 @@ const SearchBook = () => {
 
   const isLogined = useUserStore((state) => state.isLogined);
   const setIsLogined = useUserStore((state) => state.setIsLogined);
+  const logout = useLogout();
 
   // API 요청 함수 (requestWithAuth 사용)
   const fetchBooks = async () => {
     try {
-      const response = await requestWithAuth("GET", "/books", null, null);
+      const response = await requestWithAuth("GET", "/books", null, logout);
 
       console.log("API Response:", response); // 전체 응답 로그 출력
 
@@ -30,8 +32,7 @@ const SearchBook = () => {
     } catch (error) {
       console.error("책 정보를 불러오는 데 실패했습니다:", error);
       setBooks([]); // 오류 발생 시 빈 배열 설정
-      setIsLogined(false);
-      // navigate("/login");
+      logout();
     }
   };
 

--- a/src/pages/UserBookInfo/UserBorrowingBook.jsx
+++ b/src/pages/UserBookInfo/UserBorrowingBook.jsx
@@ -4,9 +4,11 @@ import Layout from "../../components/Layout/Layout";
 import { requestWithAuth } from "../../utils/requestWithAuth";
 import Loading from "../../components/Loading/Loading";
 import Hero from "../../components/Hero/Hero";
+import { useLogout } from "../../hooks/useLogout";
 
 const UserBorrowingBook = () => {
   const [borrowingBooks, setBorrowingBooks] = useState([]);
+  const logout = useLogout();
 
   useEffect(() => {
     requestBorrowingBooks();
@@ -14,7 +16,12 @@ const UserBorrowingBook = () => {
 
   const requestBorrowingBooks = async () => {
     try {
-      const response = await requestWithAuth("GET", "/myPage/loan");
+      const response = await requestWithAuth(
+        "GET",
+        "/myPage/loan",
+        null,
+        logout
+      );
       console.log(response.data);
       if (response === null) {
         throw new Error();
@@ -58,8 +65,7 @@ const UserBorrowingBook = () => {
                       <td>
                         {new Date(book.reservationDate).toLocaleDateString()}
                       </td>
-                      {/* <td>{new Date(book.returnDate).toLocaleDateString()}</td> */}
-                      <td>{book.returnDate}</td>
+                      <td>{new Date(book.returnDate).toLocaleDateString()}</td>
                       <td>{book.overdueDate}</td>
                     </tr>
                   ))}

--- a/src/pages/UserBookInfo/UserReservedBook.jsx
+++ b/src/pages/UserBookInfo/UserReservedBook.jsx
@@ -4,9 +4,11 @@ import { useEffect, useState } from "react";
 import { requestWithAuth } from "../../utils/requestWithAuth";
 import Loading from "../../components/Loading/Loading";
 import Hero from "../../components/Hero/Hero";
+import { useLogout } from "../../hooks/useLogout";
 
 const UserReservedBook = () => {
   const [reservedBooks, setReservedBooks] = useState([]);
+  const logout = useLogout();
 
   useEffect(() => {
     requestReservedBooks();
@@ -14,7 +16,12 @@ const UserReservedBook = () => {
 
   const requestReservedBooks = async () => {
     try {
-      const response = await requestWithAuth("GET", "/myPage/reservation");
+      const response = await requestWithAuth(
+        "GET",
+        "/myPage/reservation",
+        null,
+        logout
+      );
       console.log(response.data);
       if (response === null) {
         throw new Error();

--- a/src/pages/UserBookInfo/UserRevertBook.jsx
+++ b/src/pages/UserBookInfo/UserRevertBook.jsx
@@ -4,9 +4,11 @@ import Layout from "../../components/Layout/Layout";
 import { requestWithAuth } from "../../utils/requestWithAuth";
 import Loading from "../../components/Loading/Loading";
 import Hero from "../../components/Hero/Hero";
+import { useLogout } from "../../hooks/useLogout";
 
 const UserRevertBook = () => {
   const [revertBooks, setRevertBooks] = useState([]);
+  const logout = useLogout();
 
   useEffect(() => {
     requestReservedBooks();
@@ -14,7 +16,12 @@ const UserRevertBook = () => {
 
   const requestReservedBooks = async () => {
     try {
-      const response = await requestWithAuth("GET", "/myPage/return");
+      const response = await requestWithAuth(
+        "GET",
+        "/myPage/return",
+        null,
+        logout
+      );
       console.log(response.data);
       if (response === null) {
         throw new Error();

--- a/src/utils/token.jsx
+++ b/src/utils/token.jsx
@@ -22,17 +22,17 @@ export const RefreshAccessToken = async () => {
     }
   } catch (error) {
     console.error("Refresh Token 요청 실패:", error.response?.data || error);
-
-    if (
-      error.response?.data.code === "A008" ||
-      error.response?.data.code === "A009"
-    ) {
-      // alert("세션이 만료되었습니다. 다시 로그인해 주세요.");
-      // 로그인 페이지로 이동
-      return null;
+    const ERROR_CODE = error.response?.data.code;
+    switch (ERROR_CODE) {
+      // case "A008": //고의로 쿠키에서 RT를 삭제한 경우
+      //   break;
+      case "A009": //RT가 유효하지 않은 경우
+      case "A010": //RT가 만료된 경우
+        break;
+      default:
+        console.log(error.response?.data?.msg);
+        break;
     }
-
-    console.warn("알 수 없는 오류 발생:", error.response?.data?.msg);
     return null;
   }
 };

--- a/store/useUserStore.jsx
+++ b/store/useUserStore.jsx
@@ -10,7 +10,8 @@ const useUserStore = create(
       department: null,
       setIsLogined: (state) => set({ isLogined: state }),
       setRole: (role) => set({ role }),
-      setUserInfo: (name, department) => set({ name, department }),
+      setUserName: (name) => set({ name }),
+      setUserDepartment: (department) => set({ department }),
     }),
     {
       name: "login_state",


### PR DESCRIPTION
## ✴ PR 요약
- store훅에서 사용자 정보 상태를 '이름'과 '학과'로 분리
- RefreshToken 만료 시 자동 로그아웃 후 로그인 페이지로 이동시키기 위한 useLogout 커스텀 훅 생성
- 모든 페이지에 해당 useLogout훅을 적용하여 일관된 로그아웃 처리를 추가
- 도서 상세 조회 페이지에서 인원 수 증감 시 도서 상태가 실시간으로 반영되도록 수정
- 마이페이지의 새 비밀번호 확인 필드의 속성명 변경
- token 만료에 따른 에러 처리 로직 추가
- 로그아웃 시 메뉴바가 열리는 문제를 수정
- 특정 input 상태 강제 업데이트를 위한 공통 UserInput 컴포넌트에 key 속성 추가
## 📝 작업 상세
- 마이페이지에서 사용자가 학과 정보 수정 시 메뉴바에 바로 반영되지 않는 문제를 해결하기 위해, 기존 store훅에서 사용자 이름과 학과 정보를 분리하여 전역 학과 상태를 통해 메뉴바에 바로 업데이트되도록 처리
- 도서 상세 조회 페이지에서 인원 수가 변경되어도 도서 상태가 실시간으로 반영되지 않는 문제를 해결하기 위해 상태 검사 로직을 추가하여 인원 수 변화에 맞게 도서 상태가 바로 업데이트 되도록 수정
- 마이페이지의 새 비밀번호 확인 필드의 속성명을 confirmPassword에서 newPasswordConfirm으로 수정
- 비밀번호 수정 후 값은 초기화되지만 필드에 이전 비밀번호가 남아있는 문제가 발생해 강제 초기화를 위해 공통 UserInput 컴포넌트에 key속성을 추가하여 이전 비밀번호가 남아있지 않도록 처리
- 로그아웃 후에도 메뉴바가 열려 있는 문제가 있어, 로그아웃 시 메뉴바가 열리지 않도록 처리